### PR TITLE
fix(spectacular): support asynchronous application initializers

### DIFF
--- a/packages/internal/test-util/src/index.ts
+++ b/packages/internal/test-util/src/index.ts
@@ -1,2 +1,6 @@
+// Logging
+export * from './lib/logging/ignore-development-mode-log';
+
+// User interactions
 export * from './lib/user-interactions/create-user-interactions';
 export * from './lib/user-interactions/user-interactions';

--- a/packages/internal/test-util/src/lib/logging/ignore-development-mode-log.ts
+++ b/packages/internal/test-util/src/lib/logging/ignore-development-mode-log.ts
@@ -1,0 +1,16 @@
+export function ignoreDevelopmentModeLog(): void {
+  const _consoleLog = console.log;
+  // filter out development mode notice
+  jest.spyOn(console, 'log').mockImplementation((...args) => {
+    const [message] = args;
+
+    if (
+      typeof message === 'string' &&
+      message.startsWith('Angular is running in development mode.')
+    ) {
+      return;
+    }
+
+    _consoleLog.call(console, ...args);
+  });
+}

--- a/packages/internal/test-util/tsconfig.lib.json
+++ b/packages/internal/test-util/tsconfig.lib.json
@@ -6,7 +6,7 @@
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
-    "types": [],
+    "types": ["jest", "node"],
     "lib": ["dom", "es2018"]
   },
   "angularCompilerOptions": {

--- a/packages/spectacular/src/lib/application-testing/application-harness/create-application-harness.spec.ts
+++ b/packages/spectacular/src/lib/application-testing/application-harness/create-application-harness.spec.ts
@@ -159,6 +159,48 @@ describe(createApplicationHarness.name, () => {
     });
   });
 
+  describe('All application hooks', () => {
+    it('registers and runs the specified initializer and bootstrap listener', () => {
+      createApplicationHarness({
+        providers: [applicationInitializer, bootstrapListener],
+      });
+
+      expect(initialized).toBe(true);
+      expect(bootstrapped).toBe(true);
+    });
+
+    it('registers the specified initializer and bootstrap Angular modules', () => {
+      createApplicationHarness({
+        imports: [InitializerModule, BootstrapListenerModule],
+      });
+
+      expect(initialized).toBe(true);
+      expect(bootstrapped).toBe(true);
+    });
+
+    it('registers and runs the specified asynchronous initializer and bootstrap listener', async () => {
+      const harness = createApplicationHarness({
+        providers: [asyncApplicationInitializer, asyncBootstrapListener],
+      });
+
+      await harness.rootFixture.whenStable();
+
+      expect(initialized).toBe(true);
+      expect(bootstrapped).toBe(true);
+    });
+
+    it('registers the specified asynchronous initializer and bootstrap listener Angular modules', async () => {
+      const harness = createApplicationHarness({
+        imports: [AsyncInitializerModule, AsyncBootstrapListenerModule],
+      });
+
+      await harness.rootFixture.whenStable();
+
+      expect(initialized).toBe(true);
+      expect(bootstrapped).toBe(true);
+    });
+  });
+
   describe('Configuration', () => {
     @Injectable()
     class AdminService {}

--- a/packages/spectacular/src/lib/application-testing/application-harness/create-application-harness.spec.ts
+++ b/packages/spectacular/src/lib/application-testing/application-harness/create-application-harness.spec.ts
@@ -1,4 +1,4 @@
-import { APP_BOOTSTRAP_LISTENER, APP_INITIALIZER, FactoryProvider, Injectable, NgModule } from '@angular/core';
+import { APP_BOOTSTRAP_LISTENER, APP_INITIALIZER, ComponentRef, FactoryProvider, Injectable, NgModule } from '@angular/core';
 
 import { SpectacularAppComponent } from '../../shared/app-component/spectacular-app.component';
 import { createApplicationHarness } from './create-application-harness';
@@ -24,7 +24,11 @@ const asyncApplicationInitializer: FactoryProvider = {
 const bootstrapListener: FactoryProvider = {
   multi: true,
   provide: APP_BOOTSTRAP_LISTENER,
-  useFactory: () => (): void => {
+  useFactory: () => (component: ComponentRef<SpectacularAppComponent>): void => {
+    if (!(component.instance instanceof SpectacularAppComponent)) {
+      throw new Error('The bootstrapped component is not an instance of SpectacularAppComponent');
+    }
+
     bootstrapped = true;
   },
 };
@@ -65,16 +69,16 @@ describe(createApplicationHarness.name, () => {
   });
 
   describe('Bootstrap listeners', () => {
-    it('registers and runs the specified bootstrap listener', () => {
-      createApplicationHarness({
+    it('registers and runs the specified bootstrap listener', async () => {
+      await createApplicationHarness({
         providers: [bootstrapListener],
       });
 
       expect(bootstrapped).toBe(true);
     });
 
-    it('registers the specified bootstrap listener Angular module', () => {
-      createApplicationHarness({
+    it('registers the specified bootstrap listener Angular module', async () => {
+      await createApplicationHarness({
         imports: [BootstrapListenerModule],
       });
 
@@ -91,11 +95,9 @@ describe(createApplicationHarness.name, () => {
     });
 
     it('registers and runs the specified asynchronous initializer', async () => {
-      const harness = createApplicationHarness({
+      const harness = await createApplicationHarness({
         providers: [asyncApplicationInitializer],
       });
-
-      await harness.rootFixture.whenStable();
 
       expect(initialized).toBe(true);
     });
@@ -109,19 +111,17 @@ describe(createApplicationHarness.name, () => {
     });
 
     it('registers the specified asynchronous initializer Angular module', async () => {
-      const harness = createApplicationHarness({
+      const harness = await createApplicationHarness({
         imports: [AsyncApplicationInitializerModule],
       });
-
-      await harness.rootFixture.whenStable();
 
       expect(initialized).toBe(true);
     });
   });
 
   describe('All application hooks', () => {
-    it('registers and runs the specified initializer and bootstrap listener', () => {
-      createApplicationHarness({
+    it('registers and runs the specified initializer and bootstrap listener', async () => {
+      await createApplicationHarness({
         providers: [applicationInitializer, bootstrapListener],
       });
 
@@ -129,8 +129,8 @@ describe(createApplicationHarness.name, () => {
       expect(bootstrapped).toBe(true);
     });
 
-    it('registers the specified initializer and bootstrap Angular modules', () => {
-      createApplicationHarness({
+    it('registers the specified initializer and bootstrap Angular modules', async () => {
+      await createApplicationHarness({
         imports: [InitializerModule, BootstrapListenerModule],
       });
 
@@ -139,22 +139,18 @@ describe(createApplicationHarness.name, () => {
     });
 
     it('registers and runs the specified asynchronous initializer and bootstrap listener', async () => {
-      const harness = createApplicationHarness({
+      await createApplicationHarness({
         providers: [asyncApplicationInitializer, bootstrapListener],
       });
-
-      await harness.rootFixture.whenStable();
 
       expect(initialized).toBe(true);
       expect(bootstrapped).toBe(true);
     });
 
     it('registers the specified asynchronous initializer and bootstrap listener Angular modules', async () => {
-      const harness = createApplicationHarness({
+      await createApplicationHarness({
         imports: [AsyncApplicationInitializerModule, BootstrapListenerModule],
       });
-
-      await harness.rootFixture.whenStable();
 
       expect(initialized).toBe(true);
       expect(bootstrapped).toBe(true);
@@ -170,8 +166,8 @@ describe(createApplicationHarness.name, () => {
     })
     class AdminServiceModule {}
 
-    it('adds the specified imports', () => {
-      const harness = createApplicationHarness({
+    it('adds the specified imports', async () => {
+      const harness = await createApplicationHarness({
         imports: [AdminServiceModule],
       });
 
@@ -179,8 +175,8 @@ describe(createApplicationHarness.name, () => {
       expect(jobService).toBeInstanceOf(AdminService);
     });
 
-    it('adds the specified providers', () => {
-      const harness = createApplicationHarness({
+    it('adds the specified providers', async () => {
+      const harness = await createApplicationHarness({
         providers: [AdminService],
       });
 
@@ -190,22 +186,22 @@ describe(createApplicationHarness.name, () => {
   });
 
   describe('Bootstrapping', () => {
-    it(`bootstraps ${SpectacularAppComponent.name} without application hooks`, () => {
-      const harness = createApplicationHarness();
+    it(`bootstraps ${SpectacularAppComponent.name} without application hooks`, async () => {
+      const harness = await createApplicationHarness();
 
       expect(harness.rootComponent).toBeInstanceOf(SpectacularAppComponent);
     });
 
-    it(`bootstraps ${SpectacularAppComponent.name} with an async initializer`, () => {
-      const harness = createApplicationHarness({
+    it(`bootstraps ${SpectacularAppComponent.name} with an async initializer`, async () => {
+      const harness = await createApplicationHarness({
         providers: [asyncApplicationInitializer],
       });
 
       expect(harness.rootComponent).toBeInstanceOf(SpectacularAppComponent);
     });
 
-    it(`bootstraps ${SpectacularAppComponent.name} with a bootstrap listener`, () => {
-      const harness = createApplicationHarness({
+    it(`bootstraps ${SpectacularAppComponent.name} with a bootstrap listener`, async () => {
+      const harness = await createApplicationHarness({
         providers: [bootstrapListener],
       });
 

--- a/packages/spectacular/src/lib/application-testing/application-harness/create-application-harness.spec.ts
+++ b/packages/spectacular/src/lib/application-testing/application-harness/create-application-harness.spec.ts
@@ -1,10 +1,4 @@
-import {
-  APP_BOOTSTRAP_LISTENER,
-  APP_INITIALIZER,
-  FactoryProvider,
-  Injectable,
-  NgModule,
-} from '@angular/core';
+import { APP_BOOTSTRAP_LISTENER, APP_INITIALIZER, FactoryProvider, Injectable, NgModule } from '@angular/core';
 
 import { SpectacularAppComponent } from '../../shared/app-component/spectacular-app.component';
 import { createApplicationHarness } from './create-application-harness';
@@ -15,38 +9,25 @@ let initialized = false;
 const applicationInitializer: FactoryProvider = {
   multi: true,
   provide: APP_INITIALIZER,
-  useFactory: () => () => {
+  useFactory: () => (): void => {
     initialized = true;
   },
 };
 const asyncApplicationInitializer: FactoryProvider = {
   multi: true,
   provide: APP_INITIALIZER,
-  useFactory: () => async () => {
+  useFactory: () => async (): Promise<void> => {
     await Promise.resolve();
     initialized = true;
-  },
-};
-const asyncBootstrapListener: FactoryProvider = {
-  multi: true,
-  provide: APP_BOOTSTRAP_LISTENER,
-  useFactory: () => async () => {
-    await Promise.resolve();
-    bootstrapped = true;
   },
 };
 const bootstrapListener: FactoryProvider = {
   multi: true,
   provide: APP_BOOTSTRAP_LISTENER,
-  useFactory: () => () => {
+  useFactory: () => (): void => {
     bootstrapped = true;
   },
 };
-
-@NgModule({
-  providers: [asyncBootstrapListener],
-})
-class AsyncBootstrapListenerModule {}
 
 @NgModule({
   providers: [asyncApplicationInitializer],
@@ -92,16 +73,6 @@ describe(createApplicationHarness.name, () => {
       expect(bootstrapped).toBe(true);
     });
 
-    it('registers and runs the specified asynchronous bootstrap listener', async () => {
-      const harness = createApplicationHarness({
-        providers: [asyncBootstrapListener],
-      });
-
-      await harness.rootFixture.whenStable();
-
-      expect(bootstrapped).toBe(true);
-    });
-
     it('registers the specified bootstrap listener Angular module', () => {
       createApplicationHarness({
         imports: [BootstrapListenerModule],
@@ -109,17 +80,6 @@ describe(createApplicationHarness.name, () => {
 
       expect(bootstrapped).toBe(true);
     });
-
-    it('registers the specified asynchronous bootstrap listener Angular module', async () => {
-      const harness = createApplicationHarness({
-        imports: [AsyncBootstrapListenerModule],
-      });
-
-      await harness.rootFixture.whenStable();
-
-      expect(bootstrapped).toBe(true);
-    });
-  });
 
   describe('Initializers', () => {
     it('registers and runs the specified initializer', () => {
@@ -180,7 +140,7 @@ describe(createApplicationHarness.name, () => {
 
     it('registers and runs the specified asynchronous initializer and bootstrap listener', async () => {
       const harness = createApplicationHarness({
-        providers: [asyncApplicationInitializer, asyncBootstrapListener],
+        providers: [asyncApplicationInitializer, bootstrapListener],
       });
 
       await harness.rootFixture.whenStable();
@@ -191,7 +151,7 @@ describe(createApplicationHarness.name, () => {
 
     it('registers the specified asynchronous initializer and bootstrap listener Angular modules', async () => {
       const harness = createApplicationHarness({
-        imports: [AsyncInitializerModule, AsyncBootstrapListenerModule],
+        imports: [AsyncInitializerModule, BootstrapListenerModule],
       });
 
       await harness.rootFixture.whenStable();

--- a/packages/spectacular/src/lib/application-testing/application-harness/create-application-harness.spec.ts
+++ b/packages/spectacular/src/lib/application-testing/application-harness/create-application-harness.spec.ts
@@ -1,4 +1,11 @@
-import { APP_BOOTSTRAP_LISTENER, APP_INITIALIZER, ComponentRef, FactoryProvider, Injectable, NgModule } from '@angular/core';
+import {
+  APP_BOOTSTRAP_LISTENER,
+  APP_INITIALIZER,
+  ComponentRef,
+  FactoryProvider,
+  Injectable,
+  NgModule,
+} from '@angular/core';
 
 import { SpectacularAppComponent } from '../../shared/app-component/spectacular-app.component';
 import { createApplicationHarness } from './create-application-harness';
@@ -24,9 +31,13 @@ const asyncApplicationInitializer: FactoryProvider = {
 const bootstrapListener: FactoryProvider = {
   multi: true,
   provide: APP_BOOTSTRAP_LISTENER,
-  useFactory: () => (component: ComponentRef<SpectacularAppComponent>): void => {
+  useFactory: () => (
+    component: ComponentRef<SpectacularAppComponent>
+  ): void => {
     if (!(component.instance instanceof SpectacularAppComponent)) {
-      throw new Error('The bootstrapped component is not an instance of SpectacularAppComponent');
+      throw new Error(
+        'The bootstrapped component is not an instance of SpectacularAppComponent'
+      );
     }
 
     bootstrapped = true;
@@ -84,8 +95,9 @@ describe(createApplicationHarness.name, () => {
 
       expect(bootstrapped).toBe(true);
     });
+  });
 
-  describe('Initializers', () => {
+  describe('Application initializers', () => {
     it('registers and runs the specified initializer', () => {
       createApplicationHarness({
         providers: [applicationInitializer],

--- a/packages/spectacular/src/lib/application-testing/application-harness/create-application-harness.spec.ts
+++ b/packages/spectacular/src/lib/application-testing/application-harness/create-application-harness.spec.ts
@@ -6,6 +6,7 @@ import {
   Injectable,
   NgModule,
 } from '@angular/core';
+import { ignoreDevelopmentModeLog } from '@internal/test-util';
 
 import { SpectacularAppComponent } from '../../shared/app-component/spectacular-app.component';
 import { createApplicationHarness } from './create-application-harness';
@@ -63,20 +64,7 @@ describe(createApplicationHarness.name, () => {
   beforeEach(() => {
     bootstrapped = false;
     initialized = false;
-    const _consoleLog = console.log;
-    // filter out development mode notice
-    jest.spyOn(console, 'log').mockImplementation((...args) => {
-      const [message] = args;
-
-      if (
-        typeof message === 'string' &&
-        message.startsWith('Angular is running in development mode.')
-      ) {
-        return;
-      }
-
-      _consoleLog.call(console, ...args);
-    });
+    ignoreDevelopmentModeLog();
   });
 
   describe('Bootstrap listeners', () => {
@@ -107,7 +95,7 @@ describe(createApplicationHarness.name, () => {
     });
 
     it('registers and runs the specified asynchronous initializer', async () => {
-      const harness = await createApplicationHarness({
+      await createApplicationHarness({
         providers: [asyncApplicationInitializer],
       });
 
@@ -123,7 +111,7 @@ describe(createApplicationHarness.name, () => {
     });
 
     it('registers the specified asynchronous initializer Angular module', async () => {
-      const harness = await createApplicationHarness({
+      await createApplicationHarness({
         imports: [AsyncApplicationInitializerModule],
       });
 

--- a/packages/spectacular/src/lib/application-testing/application-harness/create-application-harness.spec.ts
+++ b/packages/spectacular/src/lib/application-testing/application-harness/create-application-harness.spec.ts
@@ -32,7 +32,7 @@ const bootstrapListener: FactoryProvider = {
 @NgModule({
   providers: [asyncApplicationInitializer],
 })
-class AsyncInitializerModule {}
+class AsyncApplicationInitializerModule {}
 
 @NgModule({
   providers: [bootstrapListener],
@@ -110,7 +110,7 @@ describe(createApplicationHarness.name, () => {
 
     it('registers the specified asynchronous initializer Angular module', async () => {
       const harness = createApplicationHarness({
-        imports: [AsyncInitializerModule],
+        imports: [AsyncApplicationInitializerModule],
       });
 
       await harness.rootFixture.whenStable();
@@ -151,7 +151,7 @@ describe(createApplicationHarness.name, () => {
 
     it('registers the specified asynchronous initializer and bootstrap listener Angular modules', async () => {
       const harness = createApplicationHarness({
-        imports: [AsyncInitializerModule, BootstrapListenerModule],
+        imports: [AsyncApplicationInitializerModule, BootstrapListenerModule],
       });
 
       await harness.rootFixture.whenStable();
@@ -190,8 +190,24 @@ describe(createApplicationHarness.name, () => {
   });
 
   describe('Bootstrapping', () => {
-    it(`bootstraps ${SpectacularAppComponent.name}`, () => {
+    it(`bootstraps ${SpectacularAppComponent.name} without application hooks`, () => {
       const harness = createApplicationHarness();
+
+      expect(harness.rootComponent).toBeInstanceOf(SpectacularAppComponent);
+    });
+
+    it(`bootstraps ${SpectacularAppComponent.name} with an async initializer`, () => {
+      const harness = createApplicationHarness({
+        providers: [asyncApplicationInitializer],
+      });
+
+      expect(harness.rootComponent).toBeInstanceOf(SpectacularAppComponent);
+    });
+
+    it(`bootstraps ${SpectacularAppComponent.name} with a bootstrap listener`, () => {
+      const harness = createApplicationHarness({
+        providers: [bootstrapListener],
+      });
 
       expect(harness.rootComponent).toBeInstanceOf(SpectacularAppComponent);
     });

--- a/packages/spectacular/src/lib/application-testing/application-harness/create-application-harness.spec.ts
+++ b/packages/spectacular/src/lib/application-testing/application-harness/create-application-harness.spec.ts
@@ -19,7 +19,22 @@ const applicationInitializer: FactoryProvider = {
     initialized = true;
   },
 };
-
+const asyncApplicationInitializer: FactoryProvider = {
+  multi: true,
+  provide: APP_INITIALIZER,
+  useFactory: () => async () => {
+    await Promise.resolve();
+    initialized = true;
+  },
+};
+const asyncBootstrapListener: FactoryProvider = {
+  multi: true,
+  provide: APP_BOOTSTRAP_LISTENER,
+  useFactory: () => async () => {
+    await Promise.resolve();
+    bootstrapped = true;
+  },
+};
 const bootstrapListener: FactoryProvider = {
   multi: true,
   provide: APP_BOOTSTRAP_LISTENER,
@@ -27,6 +42,16 @@ const bootstrapListener: FactoryProvider = {
     bootstrapped = true;
   },
 };
+
+@NgModule({
+  providers: [asyncBootstrapListener],
+})
+class AsyncBootstrapListenerModule {}
+
+@NgModule({
+  providers: [asyncApplicationInitializer],
+})
+class AsyncInitializerModule {}
 
 @NgModule({
   providers: [bootstrapListener],
@@ -67,10 +92,30 @@ describe(createApplicationHarness.name, () => {
       expect(bootstrapped).toBe(true);
     });
 
+    it('registers and runs the specified asynchronous bootstrap listener', async () => {
+      const harness = createApplicationHarness({
+        providers: [asyncBootstrapListener],
+      });
+
+      await harness.rootFixture.whenStable();
+
+      expect(bootstrapped).toBe(true);
+    });
+
     it('registers the specified bootstrap listener Angular module', () => {
       createApplicationHarness({
         imports: [BootstrapListenerModule],
       });
+
+      expect(bootstrapped).toBe(true);
+    });
+
+    it('registers the specified asynchronous bootstrap listener Angular module', async () => {
+      const harness = createApplicationHarness({
+        imports: [AsyncBootstrapListenerModule],
+      });
+
+      await harness.rootFixture.whenStable();
 
       expect(bootstrapped).toBe(true);
     });
@@ -85,10 +130,30 @@ describe(createApplicationHarness.name, () => {
       expect(initialized).toBe(true);
     });
 
+    it('registers and runs the specified asynchronous initializer', async () => {
+      const harness = createApplicationHarness({
+        providers: [asyncApplicationInitializer],
+      });
+
+      await harness.rootFixture.whenStable();
+
+      expect(initialized).toBe(true);
+    });
+
     it('registers the specified initializer Angular module', () => {
       createApplicationHarness({
         imports: [InitializerModule],
       });
+
+      expect(initialized).toBe(true);
+    });
+
+    it('registers the specified asynchronous initializer Angular module', async () => {
+      const harness = createApplicationHarness({
+        imports: [AsyncInitializerModule],
+      });
+
+      await harness.rootFixture.whenStable();
 
       expect(initialized).toBe(true);
     });

--- a/packages/spectacular/src/lib/application-testing/application-harness/create-application-harness.ts
+++ b/packages/spectacular/src/lib/application-testing/application-harness/create-application-harness.ts
@@ -2,7 +2,10 @@ import { NgZone } from '@angular/core';
 import { ComponentFixtureAutoDetect, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { SpectacularAppComponent, spectacularAppTag } from '../../shared/app-component/spectacular-app.component';
+import {
+  SpectacularAppComponent,
+  spectacularAppTag,
+} from '../../shared/app-component/spectacular-app.component';
 import { SpectacularAppModule } from '../../shared/app-component/spectacular-app.module';
 import { bootstrapComponent } from '../util-bootstrapping/bootstrap-component';
 import { CreateApplicationHarnessOptions } from './create-application-harness-options';

--- a/packages/spectacular/src/lib/application-testing/application-harness/create-application-harness.ts
+++ b/packages/spectacular/src/lib/application-testing/application-harness/create-application-harness.ts
@@ -2,10 +2,7 @@ import { NgZone } from '@angular/core';
 import { ComponentFixtureAutoDetect, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import {
-  SpectacularAppComponent,
-  spectacularAppTag,
-} from '../../shared/app-component/spectacular-app.component';
+import { SpectacularAppComponent, spectacularAppTag } from '../../shared/app-component/spectacular-app.component';
 import { SpectacularAppModule } from '../../shared/app-component/spectacular-app.module';
 import { bootstrapComponent } from '../util-bootstrapping/bootstrap-component';
 import { CreateApplicationHarnessOptions } from './create-application-harness-options';
@@ -16,10 +13,10 @@ import { SpectacularApplicationHarness } from './spectacular-application-harness
  * configuration Angular modules, bootstrap listeners, and application
  * initializers.
  */
-export function createApplicationHarness({
+export async function createApplicationHarness({
   imports = [],
   providers = [],
-}: CreateApplicationHarnessOptions = {}): SpectacularApplicationHarness {
+}: CreateApplicationHarnessOptions = {}): Promise<SpectacularApplicationHarness> {
   TestBed.configureTestingModule({
     imports: [RouterTestingModule, ...imports, SpectacularAppModule],
     providers: [...providers],
@@ -37,7 +34,7 @@ export function createApplicationHarness({
 
   const [autoDetectChanges] = autoDetectChangesArray;
 
-  const rootFixture = bootstrapComponent({
+  const rootFixture = await bootstrapComponent({
     autoDetectChanges,
     component: SpectacularAppComponent,
     ngZone: TestBed.inject(NgZone),

--- a/packages/spectacular/src/lib/application-testing/util-bootstrapping/bootstrap-component.ts
+++ b/packages/spectacular/src/lib/application-testing/util-bootstrapping/bootstrap-component.ts
@@ -20,12 +20,25 @@ export function bootstrapComponent<TRootComponent>({
   const application = TestBed.inject(ApplicationRef);
 
   ensureFreshRootElement(tag);
-  const componentRef = application.bootstrap(component);
-  const fixture = new ComponentFixture<TRootComponent>(
-    componentRef,
-    ngZone,
-    autoDetectChanges
-  );
 
-  return fixture;
+  try {
+    const componentRef = application.bootstrap(component, tag);
+    const fixture = new ComponentFixture<TRootComponent>(
+      componentRef,
+      ngZone,
+      autoDetectChanges
+    );
+
+    return fixture;
+  } catch (error) {
+    const errorMessage = (error as Error)?.message ?? String(error);
+
+    if (!errorMessage.includes('ngDoBootstrap')) {
+      throw error;
+    }
+
+    const fixture = TestBed.createComponent(component);
+
+    return fixture;
+  }
 }

--- a/packages/spectacular/src/lib/feature-testing/navigation/initial-feature-navigation.initializer.spec.ts
+++ b/packages/spectacular/src/lib/feature-testing/navigation/initial-feature-navigation.initializer.spec.ts
@@ -1,6 +1,7 @@
 import { Injectable, ValueProvider } from '@angular/core';
 import { Resolve } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { ignoreDevelopmentModeLog } from '@internal/test-util';
 
 import { createApplicationHarness } from '../../application-testing/application-harness/create-application-harness';
 import { SpectacularAppComponent } from '../../shared/app-component/spectacular-app.component';
@@ -10,6 +11,10 @@ import { initialFeatureNavigationInitializer } from './initial-feature-navigatio
 import { SpectacularFeatureLocation } from './spectacular-feature-location';
 
 describe('initialFeatureNavigationInitializer', () => {
+  beforeEach(() => {
+    ignoreDevelopmentModeLog();
+  });
+
   const featurePath = 'admin';
   const featurePathProvider: ValueProvider = {
     provide: featurePathToken,

--- a/packages/spectacular/src/lib/feature-testing/navigation/initial-feature-navigation.initializer.spec.ts
+++ b/packages/spectacular/src/lib/feature-testing/navigation/initial-feature-navigation.initializer.spec.ts
@@ -1,5 +1,4 @@
 import { Injectable, ValueProvider } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
 import { Resolve } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
@@ -18,7 +17,7 @@ describe('initialFeatureNavigationInitializer', () => {
   };
 
   it('navigates to the default feature route when the specified feature route is registered', () => {
-    createApplicationHarness({
+    const harness = createApplicationHarness({
       imports: [
         RouterTestingModule.withRoutes([
           {
@@ -31,8 +30,7 @@ describe('initialFeatureNavigationInitializer', () => {
       providers: [featurePathProvider, initialFeatureNavigationInitializer],
     });
 
-    const location = TestBed.inject(SpectacularFeatureLocation);
-
+    const location = harness.inject(SpectacularFeatureLocation);
     expect(location.path()).toBe('~/');
   });
 

--- a/packages/spectacular/src/lib/feature-testing/navigation/initial-feature-navigation.initializer.spec.ts
+++ b/packages/spectacular/src/lib/feature-testing/navigation/initial-feature-navigation.initializer.spec.ts
@@ -16,8 +16,8 @@ describe('initialFeatureNavigationInitializer', () => {
     useValue: featurePath,
   };
 
-  it('navigates to the default feature route when the specified feature route is registered', () => {
-    const harness = createApplicationHarness({
+  it('navigates to the default feature route when the specified feature route is registered', async () => {
+    const harness = await createApplicationHarness({
       imports: [
         RouterTestingModule.withRoutes([
           {
@@ -35,8 +35,8 @@ describe('initialFeatureNavigationInitializer', () => {
   });
 
   it('fails when the specified feature route has not been registered', () => {
-    const act = () =>
-      createApplicationHarness({
+    const act = async () =>
+      await createApplicationHarness({
         imports: [
           RouterTestingModule.withRoutes([
             {
@@ -49,7 +49,7 @@ describe('initialFeatureNavigationInitializer', () => {
         providers: [featurePathProvider, initialFeatureNavigationInitializer],
       });
 
-    expect(act).toThrowError('Cannot match any routes');
+    expect(act).rejects.toThrowError('Cannot match any routes');
   });
 
   it('fails when the default feature route fails to load', () => {
@@ -61,8 +61,8 @@ describe('initialFeatureNavigationInitializer', () => {
       }
     }
 
-    const act = () =>
-      createApplicationHarness({
+    const act = async () =>
+      await createApplicationHarness({
         imports: [
           RouterTestingModule.withRoutes([
             {
@@ -78,6 +78,6 @@ describe('initialFeatureNavigationInitializer', () => {
         providers: [featurePathProvider, initialFeatureNavigationInitializer],
       });
 
-    expect(act).toThrowError(errorMessage);
+    expect(act).rejects.toThrowError(errorMessage);
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Asynchronous application initializers make the application test harness fail.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Fixes #19 

## What is the new behavior?
Asynchronous application initializers work with the application test harness, but `createApplicationHarness` has to return a promise.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

BREAKING CHANGE:
`createApplicationHarness` returns `Promise<SpectacularApplicationHarness>`.

## Other information
- Refactor a test using the application harness so that it doesn't depend on `TestBed`.
- Remove development mode log from tests.