### PR TITLE
fix(spectacular): expose SpectacularFeatureTestingRootModule to prevent NGCC error when using Nx

### DIFF
--- a/packages/spectacular/README.md
+++ b/packages/spectacular/README.md
@@ -45,6 +45,7 @@ modules.
 | `SpectacularFeatureHarness`              | Interface                                     | A harness for testing an Angular feature module.                                                                            |
 | `SpectacularFeatureTestingModuleOptions` | Options for `SpectacularFeatureTestingModule` | Feature testing options for `SpectacularFeatureTestingModule.withFeature`.                                                  |
 | `SpectacularFeatureTestingModule`        | Angular testing configuration module          | Configure the `RouterTestingModule` and provide Spectactular services for testing feature modules.                          |
+| `SpectacularFeatureTestingRootModule`    | Internal Angular testing configuration module | Internal use only. Used by `SpectacularFeatureTestingModule.withFeature`.                                                   |
 | `SpectacularFeatureLocation`             | Service                                       | A subset of Angular's `Location` service adjusted to the Angular feature module under test.                                 |
 | `SpectacularFeatureRouter`               | Service                                       | A subset of Angular's `Router` service adjusted to the Angular feature module under test.                                   |
 

--- a/packages/spectacular/src/index.ts
+++ b/packages/spectacular/src/index.ts
@@ -10,6 +10,7 @@ export * from './lib/feature-testing/feature-harness/create-feature-harness-opti
 export * from './lib/feature-testing/feature-harness/spectacular-feature-harness';
 //   Feature testing module
 export * from './lib/feature-testing/feature-testing-module/spectacular-feature-testing-module-options';
+export * from './lib/feature-testing/feature-testing-module/spectacular-feature-testing-root.module';
 export * from './lib/feature-testing/feature-testing-module/spectacular-feature-testing.module';
 //   Navigation
 export * from './lib/feature-testing/navigation/spectacular-feature-location';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
When using Nx, NGCC fails after adding Spectacular.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
No NGCC error when using Nx to install Spectacular.
## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
NGCC error message when
```
node ./decorate-angular-cli.js && ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points
```
is run:
```
Error: Error on worker #4: Error: No typings declaration can be found for the referenced NgModule class in static withFeature({ featureModule, featurePath, routerOptions = {}, }) {
        const { providers: routerTestingProviders = [], } = RouterTestingModule.withRoutes([{ path: featurePath, loadChildren: () => featureModule }], routerOptions);
        return {
            ngModule: SpectacularFeatureTestingRootModule,
            providers: [
                ...routerTestingProviders,
                {
                    provide: featurePathToken,
                    useValue: featurePath,
                },
            ],
        };
    }.
    at ModuleWithProvidersAnalyzer.resolveNgModuleReference (C:\projects\sandbox\nx114-angular-app\node_modules\@angular\compiler-cli\ngcc\src\analysis\module_with_providers_analyzer.js:179:23)
    at ModuleWithProvidersAnalyzer.getDtsModuleWithProvidersFunction (C:\projects\sandbox\nx114-angular-app\node_modules\@angular\compiler-cli\ngcc\src\analysis\module_with_providers_analyzer.js:166:33)
    at C:\projects\sandbox\nx114-angular-app\node_modules\@angular\compiler-cli\ngcc\src\analysis\module_with_providers_analyzer.js:47:43    
    at Array.forEach (<anonymous>)
    at C:\projects\sandbox\nx114-angular-app\node_modules\@angular\compiler-cli\ngcc\src\analysis\module_with_providers_analyzer.js:40:28    
    at Array.forEach (<anonymous>)
    at ModuleWithProvidersAnalyzer.analyzeProgram (C:\projects\sandbox\nx114-angular-app\node_modules\@angular\compiler-cli\ngcc\src\analysis\module_with_providers_analyzer.js:38:23)
    at Transformer.analyzeProgram (C:\projects\sandbox\nx114-angular-app\node_modules\@angular\compiler-cli\ngcc\src\packages\transformer.js:133:45)
    at Transformer.transform (C:\projects\sandbox\nx114-angular-app\node_modules\@angular\compiler-cli\ngcc\src\packages\transformer.js:76:27)
    at C:\projects\sandbox\nx114-angular-app\node_modules\@angular\compiler-cli\ngcc\src\execution\create_compile_function.js:52:42
    at ClusterMaster.onWorkerMessage (C:\projects\sandbox\nx114-angular-app\node_modules\@angular\compiler-cli\ngcc\src\execution\cluster\master.js:195:27)
    at C:\projects\sandbox\nx114-angular-app\node_modules\@angular\compiler-cli\ngcc\src\execution\cluster\master.js:55:95
    at ClusterMaster.<anonymous> (C:\projects\sandbox\nx114-angular-app\node_modules\@angular\compiler-cli\ngcc\src\execution\cluster\master.js:293:57)
    at step (C:\projects\sandbox\nx114-angular-app\node_modules\tslib\tslib.js:143:27)
    at Object.next (C:\projects\sandbox\nx114-angular-app\node_modules\tslib\tslib.js:124:57)
    at C:\projects\sandbox\nx114-angular-app\node_modules\tslib\tslib.js:117:75
    at new Promise (<anonymous>)
    at Object.__awaiter (C:\projects\sandbox\nx114-angular-app\node_modules\tslib\tslib.js:113:16)
    at EventEmitter.<anonymous> (C:\projects\sandbox\nx114-angular-app\node_modules\@angular\compiler-cli\ngcc\src\execution\cluster\master.js:287:32)
    at EventEmitter.emit (events.js:314:20)
```