### PR TITLE
fix(spectacular): remove @angular/forms dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,12 @@ jobs:
         run: pnpm build
       - if: github.event_name == 'pull_request'
         run: pnpm affected:build -- --base=$BASE_BRANCH
-      - uses: actions/upload-artifact@v2
+      - name: 'Spectacular: Remove @angular/forms dependency'
+        run:
+          pnpx json -I -f dist/packages/spectacular/package.json -e "delete
+          this.dependencies['@angular/forms'];" || true
+      - name: 'Spectacular: Upload package build artifact'
+        uses: actions/upload-artifact@v2
         with:
           name: spectacular-package
           path: dist/packages/spectacular

--- a/packages/spectacular/package.json
+++ b/packages/spectacular/package.json
@@ -7,7 +7,8 @@
     "@angular/common": "^11.0.9",
     "@angular/core": "^11.0.9",
     "@angular/platform-browser": "^11.0.9",
-    "@angular/router": "^11.0.9"
+    "@angular/router": "^11.0.9",
+    "rxjs": "^6.5.5"
   },
   "dependencies": {
     "tslib": "^2.0.0"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
`@angular/forms` and `rxjs` are listed as `dependencies` in the Spectacular bundle.

Spectacular doesn't have a dependency on `@angular/forms` and only uses type imports from `rxjs`.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
- `@angular/forms` is not listed in Spectacular's bundle.
- `rxjs` is listed as a peer dependency in Spectacular's bundle.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
