### PR TITLE
feat(spectacular): remove `pipeName` option

### DIFF
--- a/packages/spectacular/package.json
+++ b/packages/spectacular/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@angular/common": "^11.0.9",
+    "@angular/compiler": "^11.0.9",
     "@angular/core": "^11.0.9",
     "@angular/platform-browser": "^11.0.9",
     "@angular/router": "^11.0.9",

--- a/packages/spectacular/src/lib/pipe-testing/capitalize.pipe.integration.spec.ts
+++ b/packages/spectacular/src/lib/pipe-testing/capitalize.pipe.integration.spec.ts
@@ -3,10 +3,8 @@ import { Pipe, PipeTransform } from '@angular/core';
 import { createPipeHarness } from './pipe-harness/create-pipe-harness';
 import { SpectacularPipeHarness } from './pipe-harness/spectacular-pipe-harness';
 
-const capitalizePipeName = 'capitalize';
-
 @Pipe({
-  name: capitalizePipeName,
+  name: 'capitalize',
 })
 export class CapitalizePipe implements PipeTransform {
   transform(value: string): string {
@@ -21,7 +19,6 @@ describe(CapitalizePipe.name, () => {
   beforeEach(() => {
     harness = createPipeHarness({
       pipe: CapitalizePipe,
-      pipeName: capitalizePipeName,
       value: 'mr. potato head',
     });
   });

--- a/packages/spectacular/src/lib/pipe-testing/metadata/get-pipe-annotation.spec.ts
+++ b/packages/spectacular/src/lib/pipe-testing/metadata/get-pipe-annotation.spec.ts
@@ -58,7 +58,7 @@ describe(getPipeAnnotation.name, () => {
     class NoopDirective {}
 
     expect(() => {
-      // @ts-expect-error
+      // @ts-expect-error Only pipes are allowed
       getPipeAnnotation(NoopDirective);
     }).toThrowError('No Pipe decorator');
   });

--- a/packages/spectacular/src/lib/pipe-testing/metadata/get-pipe-annotation.spec.ts
+++ b/packages/spectacular/src/lib/pipe-testing/metadata/get-pipe-annotation.spec.ts
@@ -1,0 +1,63 @@
+import { Directive, Injectable, Pipe, PipeTransform } from '@angular/core';
+
+import { getPipeAnnotation } from './get-pipe-annotation';
+
+describe(getPipeAnnotation.name, () => {
+  it('resolves the pipe annotation of a pipe without dependencies', () => {
+    const expectedName = 'noop';
+    @Pipe({
+      name: expectedName,
+    })
+    class NoopPipe implements PipeTransform {
+      transform() {
+        // No-op
+      }
+    }
+
+    const annotation = getPipeAnnotation(NoopPipe);
+
+    expect(annotation).toEqual({
+      name: expectedName,
+      pure: true,
+    });
+  });
+
+  it('resolves the pipe annotation of a pipe with dependencies', () => {
+    @Injectable({
+      providedIn: 'root',
+    })
+    class Bananas {}
+    @Injectable({
+      providedIn: 'root',
+    })
+    class Veggies {}
+    const expectedName = 'deps';
+    @Pipe({
+      name: expectedName,
+    })
+    class DepsPipe implements PipeTransform {
+      constructor(bananas: Bananas, veggies: Veggies) {}
+
+      transform() {
+        // No-op
+      }
+    }
+
+    const annotation = getPipeAnnotation(DepsPipe);
+
+    expect(annotation).toEqual({
+      name: expectedName,
+      pure: true,
+    });
+  });
+
+  it('throws when a non-pipe is passed', () => {
+    @Directive({})
+    class NoopDirective {}
+
+    expect(() => {
+      // @ts-expect-error
+      getPipeAnnotation(NoopDirective);
+    }).toThrowError('No Pipe decorator');
+  });
+});

--- a/packages/spectacular/src/lib/pipe-testing/metadata/get-pipe-annotation.spec.ts
+++ b/packages/spectacular/src/lib/pipe-testing/metadata/get-pipe-annotation.spec.ts
@@ -38,7 +38,9 @@ describe(getPipeAnnotation.name, () => {
     class DepsPipe implements PipeTransform {
       // Just here for testing dependencies
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      constructor(bananas: Bananas, veggies: Veggies) {}
+      constructor(bananas: Bananas, veggies: Veggies) {
+        // No-op
+      }
 
       transform() {
         // No-op

--- a/packages/spectacular/src/lib/pipe-testing/metadata/get-pipe-annotation.spec.ts
+++ b/packages/spectacular/src/lib/pipe-testing/metadata/get-pipe-annotation.spec.ts
@@ -36,6 +36,8 @@ describe(getPipeAnnotation.name, () => {
       name: expectedName,
     })
     class DepsPipe implements PipeTransform {
+      // Just here for testing dependencies
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       constructor(bananas: Bananas, veggies: Veggies) {}
 
       transform() {

--- a/packages/spectacular/src/lib/pipe-testing/metadata/get-pipe-annotation.ts
+++ b/packages/spectacular/src/lib/pipe-testing/metadata/get-pipe-annotation.ts
@@ -1,0 +1,18 @@
+import { PipeResolver } from '@angular/compiler';
+import {
+  Pipe,
+  PipeTransform,
+  Type,
+  ɵReflectionCapabilities as ReflectionCapabilities,
+} from '@angular/core';
+
+export function getPipeAnnotation(pipeType: Type<PipeTransform>): Pipe {
+  // `PipeResolver` is using the `annotations` method only
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const pipeResolver = new PipeResolver(new ReflectionCapabilities() as any);
+  const pipeAnnotation = pipeResolver.resolve(pipeType, true);
+
+  // `PipeResolver` throws if a pipe annotation cannot be resolved
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return pipeAnnotation!;
+}

--- a/packages/spectacular/src/lib/pipe-testing/pipe-harness/create-pipe-harness-options.ts
+++ b/packages/spectacular/src/lib/pipe-testing/pipe-harness/create-pipe-harness-options.ts
@@ -8,10 +8,6 @@ import type { Observable } from 'rxjs';
 export interface CreatePipeHarnessOptions<TValue>
   extends Pick<NgModule, 'declarations' | 'imports' | 'providers'> {
   /**
-   * The name of the Angular pipe-under-test, for example `camelize`.
-   */
-  readonly pipeName: string;
-  /**
    * The type of the Angular pipe-under-test, for example `CamelizePipe`.
    */
   readonly pipe: Type<PipeTransform>;

--- a/packages/spectacular/src/lib/pipe-testing/pipe-harness/create-pipe-harness.spec.ts
+++ b/packages/spectacular/src/lib/pipe-testing/pipe-harness/create-pipe-harness.spec.ts
@@ -1,9 +1,6 @@
 import { Injectable, NgModule, Pipe, PipeTransform } from '@angular/core';
 
-import {
-  PassthroughPipe,
-  passthroughPipeName,
-} from '../test-util/passthrough.pipe';
+import { PassthroughPipe } from '../test-util/passthrough.pipe';
 import { createPipeHarness } from './create-pipe-harness';
 
 describe(createPipeHarness.name, () => {
@@ -20,7 +17,6 @@ describe(createPipeHarness.name, () => {
       const harness = createPipeHarness({
         imports: [PipeServiceModule],
         pipe: PassthroughPipe,
-        pipeName: passthroughPipeName,
         value: null,
       });
 
@@ -32,7 +28,6 @@ describe(createPipeHarness.name, () => {
       const harness = createPipeHarness({
         providers: [PipeService],
         pipe: PassthroughPipe,
-        pipeName: passthroughPipeName,
         value: null,
       });
 
@@ -53,8 +48,7 @@ describe(createPipeHarness.name, () => {
       const harness = createPipeHarness({
         declarations: [RepeatPipe],
         pipe: PassthroughPipe,
-        pipeName: passthroughPipeName,
-        template: `{{ value | ${passthroughPipeName} | testRepeat:4 }}`,
+        template: `{{ value | testPassthrough | testRepeat:4 }}`,
         value: 'Boom',
       });
 

--- a/packages/spectacular/src/lib/pipe-testing/pipe-harness/create-pipe-harness.ts
+++ b/packages/spectacular/src/lib/pipe-testing/pipe-harness/create-pipe-harness.ts
@@ -1,18 +1,12 @@
-import { PipeResolver } from '@angular/compiler';
-import {
-  PipeTransform,
-  Type,
-  ɵReflectionCapabilities as ReflectionCapabilities,
-} from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
+import { getPipeAnnotation } from '../metadata/get-pipe-annotation';
 import { SpectacularPipeComponent } from '../pipe-component/spectacular-pipe.component';
 import { CreatePipeHarnessOptions } from './create-pipe-harness-options';
 import { SpectacularPipeHarness } from './spectacular-pipe-harness';
 
 import type { Observable } from 'rxjs';
-
 function createPipeComponentTemplate(innerTemplate: string): string {
   return `<span id="${textId}">${innerTemplate}</span>`;
 }
@@ -29,17 +23,6 @@ function createPipeFixture<TValue>(
   return pipeFixture;
 }
 
-function getPipeName(pipeType: Type<PipeTransform>): string {
-  // `PipeResolver` is using the `annotations` method only
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const pipeResolver = new PipeResolver(new ReflectionCapabilities() as any);
-  const pipeAnnotation = pipeResolver.resolve(pipeType, true);
-
-  // `PipeResolver` throws if a pipe annotation cannot be resolved
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return pipeAnnotation!.name;
-}
-
 /**
  * Set up a host component for the Angular pipe under test.
  *
@@ -50,7 +33,7 @@ export function createPipeHarness<TValue>({
   imports = [],
   pipe,
   providers = [],
-  template = `{{ value | ${getPipeName(pipe)} }}`,
+  template = `{{ value | ${getPipeAnnotation(pipe).name} }}`,
   value,
 }: CreatePipeHarnessOptions<TValue>): SpectacularPipeHarness<TValue> {
   function configureTestbed(template: string): void | never {

--- a/packages/spectacular/src/lib/pipe-testing/pipe-harness/create-pipe-harness.ts
+++ b/packages/spectacular/src/lib/pipe-testing/pipe-harness/create-pipe-harness.ts
@@ -1,3 +1,9 @@
+import { PipeResolver } from '@angular/compiler';
+import {
+  PipeTransform,
+  Type,
+  ɵReflectionCapabilities as ReflectionCapabilities,
+} from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -6,8 +12,6 @@ import { CreatePipeHarnessOptions } from './create-pipe-harness-options';
 import { SpectacularPipeHarness } from './spectacular-pipe-harness';
 
 import type { Observable } from 'rxjs';
-
-const textId = '__SPECTACULAR_PIPE_COMPONENT_TEXT__';
 
 function createPipeComponentTemplate(innerTemplate: string): string {
   return `<span id="${textId}">${innerTemplate}</span>`;
@@ -25,6 +29,17 @@ function createPipeFixture<TValue>(
   return pipeFixture;
 }
 
+function getPipeName(pipeType: Type<PipeTransform>): string {
+  // `PipeResolver` is using the `annotations` method only
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const pipeResolver = new PipeResolver(new ReflectionCapabilities() as any);
+  const pipeAnnotation = pipeResolver.resolve(pipeType, true);
+
+  // `PipeResolver` throws if a pipe annotation cannot be resolved
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return pipeAnnotation!.name;
+}
+
 /**
  * Set up a host component for the Angular pipe under test.
  *
@@ -34,9 +49,8 @@ export function createPipeHarness<TValue>({
   declarations = [],
   imports = [],
   pipe,
-  pipeName,
   providers = [],
-  template = `{{ value | ${pipeName} }}`,
+  template = `{{ value | ${getPipeName(pipe)} }}`,
   value,
 }: CreatePipeHarnessOptions<TValue>): SpectacularPipeHarness<TValue> {
   function configureTestbed(template: string): void | never {
@@ -81,3 +95,5 @@ export function createPipeHarness<TValue>({
     },
   };
 }
+
+const textId = '__SPECTACULAR_PIPE_COMPONENT_TEXT__';

--- a/packages/spectacular/src/lib/pipe-testing/test-util/create-common-pipe-harness.ts
+++ b/packages/spectacular/src/lib/pipe-testing/test-util/create-common-pipe-harness.ts
@@ -1,7 +1,7 @@
 import { createPipeHarness } from '../pipe-harness/create-pipe-harness';
 import { SpectacularPipeHarness } from '../pipe-harness/spectacular-pipe-harness';
 import { CreateCommonPipeHarnessOptions } from './create-common-pipe-harness-options';
-import { PassthroughPipe, passthroughPipeName } from './passthrough.pipe';
+import { PassthroughPipe } from './passthrough.pipe';
 
 /**
  * Wraps `createPipeHarness` and allows the consumer to test the built-in
@@ -12,7 +12,6 @@ export function createCommonPipeHarness<TValue>({
   value,
 }: CreateCommonPipeHarnessOptions<TValue>): SpectacularPipeHarness<TValue> {
   return createPipeHarness({
-    pipeName: passthroughPipeName,
     pipe: PassthroughPipe,
     value,
     template,

--- a/packages/spectacular/src/lib/pipe-testing/test-util/passthrough.pipe.ts
+++ b/packages/spectacular/src/lib/pipe-testing/test-util/passthrough.pipe.ts
@@ -1,9 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-export const passthroughPipeName = 'testPassthrough';
-
 @Pipe({
-  name: passthroughPipeName,
+  name: 'testPassthrough',
 })
 export class PassthroughPipe<TValue> implements PipeTransform {
   transform(value: TValue | null): TValue | null {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
A `pipeName` option is required for `createPipeHarness`.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
The `pipeName` option for `createPipeHarness` is removed. Instead, the pipe name is resolved through reflection.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Migration: Remove `pipeName` option arguments for `createPipeHarness`.

## Other information
Cc @timdeschryver