### PR TITLE
refactor(spectacular): replace constructor injection with `inject`

### DIFF
--- a/packages/spectacular/src/lib/feature-testing/configuration/feature-path.token.ts
+++ b/packages/spectacular/src/lib/feature-testing/configuration/feature-path.token.ts
@@ -5,7 +5,7 @@ import { InjectionToken } from '@angular/core';
  * Internal dependency used to pass the feature route path to Spectacular
  * feature testing services.
  */
-export const featurePathToken = new InjectionToken(
+export const featurePathToken = new InjectionToken<string>(
   '__SPECTACULAR_INTERNAL_FEATURE_PATH__'
 );
 

--- a/packages/spectacular/src/lib/feature-testing/feature-testing-module/spectacular-feature-testing-root.module.spec.ts
+++ b/packages/spectacular/src/lib/feature-testing/feature-testing-module/spectacular-feature-testing-root.module.spec.ts
@@ -4,7 +4,6 @@ import { Component, NgModule, ViewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { Router, RouterModule, RouterOutlet } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-
 import { SpectacularAppComponent } from '../../shared/app-component/spectacular-app.component';
 import { SpectacularFeatureTestingRootModule } from './spectacular-feature-testing-root.module';
 
@@ -32,8 +31,6 @@ class TestRootComponent {
 })
 class TestRootModule {}
 
-const optionalAngularDependency = null;
-
 describe(SpectacularFeatureTestingRootModule.name, () => {
   describe('Routing', () => {
     it(`makes ${SpectacularAppComponent.name} routable`, async () => {
@@ -53,7 +50,8 @@ describe(SpectacularFeatureTestingRootModule.name, () => {
       await rootFixture.ngZone?.run(() => router.navigate([path]));
       rootFixture.detectChanges();
 
-      const activeComponent = rootFixture.componentInstance.getActiveComponent();
+      const activeComponent =
+        rootFixture.componentInstance.getActiveComponent();
       expect(activeComponent).toBeInstanceOf(SpectacularAppComponent);
     });
 
@@ -69,24 +67,35 @@ describe(SpectacularFeatureTestingRootModule.name, () => {
 
   describe('Dependency injection', () => {
     it('guards against being registered in multiple injectors', () => {
-      const rootInjectorInstance = new SpectacularFeatureTestingRootModule(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        optionalAngularDependency as any
-      );
+      @NgModule({
+        imports: [SpectacularFeatureTestingRootModule],
+      })
+      class TestChildModule {}
 
-      expect(
-        () => new SpectacularFeatureTestingRootModule(rootInjectorInstance)
-      ).toThrowError(/multiple injectors/);
+      expect.assertions(1);
+      TestBed.configureTestingModule({
+        imports: [
+          SpectacularFeatureTestingRootModule,
+          RouterTestingModule.withRoutes([
+            { path: 'child', loadChildren: () => TestChildModule },
+          ]),
+        ],
+      });
+      const router = TestBed.inject(Router);
+
+      const act = () => router.navigateByUrl('/child');
+
+      expect(act).rejects.toThrowError(/multiple injectors/);
     });
 
     it('does not guard the first injector that registers it', () => {
-      expect(
-        () =>
-          new SpectacularFeatureTestingRootModule(
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            optionalAngularDependency as any
-          )
-      ).not.toThrow();
+      TestBed.configureTestingModule({
+        imports: [SpectacularFeatureTestingRootModule],
+      });
+
+      const act = () => TestBed.inject(SpectacularFeatureTestingRootModule);
+
+      expect(act).not.toThrow();
     });
   });
 });

--- a/packages/spectacular/src/lib/feature-testing/feature-testing-module/spectacular-feature-testing-root.module.ts
+++ b/packages/spectacular/src/lib/feature-testing/feature-testing-module/spectacular-feature-testing-root.module.ts
@@ -1,6 +1,5 @@
-import { NgModule, Optional, SkipSelf } from '@angular/core';
+import { inject, InjectFlags, NgModule } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
-
 import { SpectacularAppScam } from '../../shared/app-component/spectacular-app.scam';
 
 /**
@@ -14,11 +13,12 @@ import { SpectacularAppScam } from '../../shared/app-component/spectacular-app.s
   imports: [RouterTestingModule, SpectacularAppScam],
 })
 export class SpectacularFeatureTestingRootModule {
-  constructor(
-    @Optional()
-    @SkipSelf()
-    maybeNgModuleFromParentInjector: SpectacularFeatureTestingRootModule
-  ) {
+  constructor() {
+    const maybeNgModuleFromParentInjector = inject(
+      SpectacularFeatureTestingRootModule,
+      InjectFlags.Optional | InjectFlags.SkipSelf
+    );
+
     if (maybeNgModuleFromParentInjector) {
       throw new Error(
         'SpectacularFeatureTestingModule.withFeature is registered in ' +

--- a/packages/spectacular/src/lib/feature-testing/navigation/spectacular-feature-location.ts
+++ b/packages/spectacular/src/lib/feature-testing/navigation/spectacular-feature-location.ts
@@ -1,5 +1,5 @@
 import { Location } from '@angular/common';
-import { Inject, Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { featurePathToken } from '../configuration/feature-path.token';
 import { ensureLeadingCharacter } from '../util-text/ensure-leading-character';
 import { trimLeadingText } from '../util-text/trim-leading-text';
@@ -11,16 +11,8 @@ import { relativeFeatureUrlPrefix } from './relative-feature-url-prefix';
  */
 @Injectable()
 export class SpectacularFeatureLocation {
-  readonly #featurePath: string;
-  readonly #location: Location;
-
-  constructor(
-    @Inject(featurePathToken) featurePath: string,
-    location: Location
-  ) {
-    this.#featurePath = featurePath;
-    this.#location = location;
-  }
+  readonly #featurePath = inject(featurePathToken);
+  readonly #location = inject(Location);
 
   /**
    * Normalizes the URL path for this location. URLs within the Angular feature

--- a/packages/spectacular/src/lib/feature-testing/navigation/spectacular-feature-router.ts
+++ b/packages/spectacular/src/lib/feature-testing/navigation/spectacular-feature-router.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, NgZone } from '@angular/core';
+import { inject, Injectable, NgZone } from '@angular/core';
 import type { NavigationExtras, UrlTree } from '@angular/router';
 import { Router, UrlSegment } from '@angular/router';
 import { featurePathToken } from '../configuration/feature-path.token';
@@ -11,19 +11,9 @@ import { relativeFeatureUrlPrefix } from './relative-feature-url-prefix';
  */
 @Injectable()
 export class SpectacularFeatureRouter {
-  readonly #featurePath: string;
-  readonly #router: Router;
-  readonly #ngZone: NgZone;
-
-  constructor(
-    @Inject(featurePathToken) featurePath: string,
-    router: Router,
-    ngZone: NgZone
-  ) {
-    this.#featurePath = featurePath;
-    this.#router = router;
-    this.#ngZone = ngZone;
-  }
+  readonly #featurePath = inject(featurePathToken);
+  readonly #router = inject(Router);
+  readonly #ngZone = inject(NgZone);
 
   /**
    * Navigate based on the provided array of commands and a starting point. If


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

1. Type-annotated and `Inject`-decorated constructor parameters are used for dependency injection.
1. The `featurePathToken` has no type parameter.

Issue Number: N/A

## What is the new behavior?

1. The `inject` function is used for dependency injection to comply with ECMAScript Decorators and hide implementation details from consumers.
1. The `featurePathToken`'s type parameter is `string`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
