### PR TITLE
fix(spectacular): run `SpectacularApplicationHarness.inject` in `TestBed`'s injection context to resolve `NG0203`

### DIFF
--- a/packages/spectacular/src/lib/application-testing/application-harness/create-application-harness.ts
+++ b/packages/spectacular/src/lib/application-testing/application-harness/create-application-harness.ts
@@ -34,8 +34,9 @@ export async function createApplicationHarness(
 
   TestBed.compileComponents();
 
-  let autoDetectChangesArray: boolean | readonly boolean[] = TestBed.inject(ComponentFixtureAutoDetect,
-    true,
+  let autoDetectChangesArray: boolean | readonly boolean[] = TestBed.inject(
+    ComponentFixtureAutoDetect,
+    true
   );
 
   if (!Array.isArray(autoDetectChangesArray)) {

--- a/packages/spectacular/src/lib/application-testing/application-harness/create-application-harness.ts
+++ b/packages/spectacular/src/lib/application-testing/application-harness/create-application-harness.ts
@@ -1,6 +1,6 @@
 import type { NgModule } from '@angular/core';
 import { NgZone } from '@angular/core';
-import { ComponentFixtureAutoDetect, TestBed } from '@angular/core/testing';
+import { ComponentFixtureAutoDetect, TestBed, getTestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import {
   SpectacularAppComponent,
@@ -34,10 +34,10 @@ export async function createApplicationHarness(
 
   TestBed.compileComponents();
 
-  let autoDetectChangesArray: boolean | readonly boolean[] = TestBed.inject(
+  let autoDetectChangesArray: boolean | readonly boolean[] = TestBed.runInInjectionContext(() => TestBed.inject(
     ComponentFixtureAutoDetect,
     true
-  );
+  ));
 
   if (!Array.isArray(autoDetectChangesArray)) {
     autoDetectChangesArray = [autoDetectChangesArray];
@@ -45,16 +45,17 @@ export async function createApplicationHarness(
 
   const [autoDetectChanges] = autoDetectChangesArray;
 
+  const ngZone = TestBed.runInInjectionContext(() => TestBed.inject(NgZone));
   const rootFixture = await bootstrapComponent({
     autoDetectChanges,
     component: SpectacularAppComponent,
-    ngZone: TestBed.inject(NgZone),
+    ngZone,
     tag: spectacularAppTag,
   });
 
   return {
-    inject(...args: unknown[]) {
-      return TestBed.runInInjectionContext(() => TestBed.apply(TestBed, args))
+    inject(token: any, notFoundValue: any, optionsOrFlags: any) {
+      return TestBed.runInInjectionContext(() => TestBed.inject(token, notFoundValue, optionsOrFlags));
     },
     get rootComponent() {
       return rootFixture.componentInstance;

--- a/packages/spectacular/src/lib/application-testing/application-harness/create-application-harness.ts
+++ b/packages/spectacular/src/lib/application-testing/application-harness/create-application-harness.ts
@@ -53,7 +53,9 @@ export async function createApplicationHarness(
   });
 
   return {
-    inject: TestBed.inject.bind(TestBed),
+    inject(...args: unknown[]) {
+      return TestBed.runInInjectionContext(() => TestBed.apply(TestBed, args))
+    },
     get rootComponent() {
       return rootFixture.componentInstance;
     },

--- a/packages/spectacular/src/lib/application-testing/util-bootstrapping/bootstrap-component.ts
+++ b/packages/spectacular/src/lib/application-testing/util-bootstrapping/bootstrap-component.ts
@@ -11,8 +11,8 @@ export interface BootstrapComponentOptions<TRootComponent> {
 }
 
 async function waitForApplicationInitializers(): Promise<void> {
-  const applicationInitStatus = TestBed.inject(ApplicationInitStatus);
-  await applicationInitStatus.donePromise;
+  const applicationInitStatus = TestBed.runInInjectionContext(() => TestBed.inject(ApplicationInitStatus));
+  await TestBed.runInInjectionContext(() => applicationInitStatus.donePromise);
 }
 
 /**
@@ -32,14 +32,14 @@ export async function bootstrapComponent<TRootComponent>({
 > {
   await waitForApplicationInitializers();
 
-  ensureFreshRootElement(tag);
-  const application = TestBed.inject(ApplicationRef);
-  const componentRef = application.bootstrap(component, tag);
-  const fixture = new ComponentFixture<TRootComponent>(
+  TestBed.runInInjectionContext(() => ensureFreshRootElement(tag));
+  const application = TestBed.runInInjectionContext(() => TestBed.inject(ApplicationRef));
+  const componentRef = TestBed.runInInjectionContext(() => application.bootstrap(component, tag));
+  const fixture = TestBed.runInInjectionContext(() => new ComponentFixture<TRootComponent>(
     componentRef,
     ngZone,
     autoDetectChanges
-  );
+  ));
 
   return fixture;
 }

--- a/packages/spectacular/src/lib/application-testing/util-dom/create-template.ts
+++ b/packages/spectacular/src/lib/application-testing/util-dom/create-template.ts
@@ -8,7 +8,7 @@ import { TestBed } from '@angular/core/testing';
  * @returns The template wrapping the specified markup.
  */
 export function createTemplate(html: string): HTMLElement {
-  const doc = TestBed.inject(DOCUMENT);
+  const doc = TestBed.runInInjectionContext(() => TestBed.inject(DOCUMENT));
 
   const templateElement = doc.createElement('template');
   templateElement.innerHTML = html;

--- a/packages/spectacular/src/lib/application-testing/util-dom/replace-root-element.ts
+++ b/packages/spectacular/src/lib/application-testing/util-dom/replace-root-element.ts
@@ -10,7 +10,7 @@ import { detach } from './detach';
  * @param newRootElement The root element to attach.
  */
 export function replaceRootElement(newRootElement: HTMLElement): void {
-  const doc = TestBed.inject(DOCUMENT);
+  const doc = TestBed.runInInjectionContext(() => TestBed.inject(DOCUMENT));
 
   doc
     .querySelectorAll(newRootElement.tagName)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

1. When using `createApplicationHarnesss` in `@ngworker/spectacular`@`16.0.0-alpha.0` with Angular 17.3, an `NG0203` error is thrown

Issue Number: N/A

## What is the new behavior?

1. `SpectacularApplicationHarness.inject` is run in `TestBed`'s injection context and no error is thrown

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
