### PR TITLE
ci(copilot): leave `versioned_docs` untouched

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,12 +17,13 @@ Use the Conventional Commits format for commit messages
 
 # Documentation
 
-Consider whether we should add documentation, including
+Consider whether we should add or update documentation, including
 
 - README.md files in projects
 - Inline JSDoc/TSDoc comments
 - Code comments
 - Markdown in the `spectacular-docs` project
+  - Never touch `versioned_docs` unless instructed to do so
 
 # Unit tests
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: Copilot instructions
```

## What is the current behavior?

1. Copilot might change `versioned_docs` documents

Issue Number: N/A

## What is the new behavior?

1. Copilot does not change `versioned_docs` documents unless explicitly instructed to

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
