### PR TITLE
ci(github): set read-only permissions for CI Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: '@ngworker CI pipeline'
 
+permissions:
+  contents: read
+
 env:
   BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
   NODE_OPTIONS: --max-old-space-size=6144


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

GitHub Code scanning outputs an `actions/missing-workflow-permissions` alert

Issue Number: https://github.com/ngworker/ngworker/security/code-scanning/4

## What is the new behavior?

The `CI` Actions workflow has read-only permissions by default to be more secure.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
